### PR TITLE
Fix installation fails

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -3,3 +3,5 @@
 - [Read the README in English](README.md)
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)
+- [Le o README en galego](README_gl.md)
+- [阅读中文（简体）的 README](README_zh_Hans.md)

--- a/README_gl.md
+++ b/README_gl.md
@@ -1,0 +1,58 @@
+<!--
+NOTA: Este README foi creado automáticamente por <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+NON debe editarse manualmente.
+-->
+
+# Crab Fit para YunoHost
+
+[![Nivel de integración](https://dash.yunohost.org/integration/crabfit.svg)](https://dash.yunohost.org/appci/app/crabfit) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/crabfit.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/crabfit.maintain.svg)
+
+[![Instalar Crab Fit con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=crabfit)
+
+*[Le este README en outros idiomas.](./ALL_README.md)*
+
+> *Este paquete permíteche instalar Crab Fit de xeito rápido e doado nun servidor YunoHost.*  
+> *Se non usas YunoHost, le a [documentación](https://yunohost.org/install) para saber como instalalo.*
+
+## Vista xeral
+
+Crab Fit helps you fit your event around everyone's schedules.
+Simply create an event above and send the link to everyone that is participating.
+Results update live and you will be able to see a heat-map of when everyone is free.
+
+## Features
+
+- Click and slide to select multiple time slots at once.
+- Editable using a one-time password
+
+
+**Versión proporcionada:** 1.0~ynh2
+
+**Demo:** <https://crab.fit>
+
+## Capturas de pantalla
+
+![Captura de pantalla de Crab Fit](./doc/screenshots/main.png)
+
+## Documentación e recursos
+
+- Web oficial da app: <https://crab.fit>
+- Documentación oficial para usuarias: <https://github.com/GRA0007/crab.fit>
+- Documentación oficial para admin: <https://github.com/GRA0007/crab.fit>
+- Repositorio de orixe do código: <https://github.com/GRA0007/crab.fit>
+- Tenda YunoHost: <https://apps.yunohost.org/app/crabfit>
+- Informar dun problema: <https://github.com/YunoHost-Apps/crabfit_ynh/issues>
+
+## Info de desenvolvemento
+
+Envía a túa colaboración á [rama `testing`](https://github.com/YunoHost-Apps/crabfit_ynh/tree/testing).
+
+Para probar a rama `testing`, procede deste xeito:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/crabfit_ynh/tree/testing --debug
+ou
+sudo yunohost app upgrade crabfit -u https://github.com/YunoHost-Apps/crabfit_ynh/tree/testing --debug
+```
+
+**Máis info sobre o empaquetado da app:** <https://yunohost.org/packaging_apps>

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -1,0 +1,58 @@
+<!--
+注意：此 README 由 <https://github.com/YunoHost/apps/tree/master/tools/readme_generator> 自动生成
+请勿手动编辑。
+-->
+
+# YunoHost 的 Crab Fit
+
+[![集成程度](https://dash.yunohost.org/integration/crabfit.svg)](https://dash.yunohost.org/appci/app/crabfit) ![工作状态](https://ci-apps.yunohost.org/ci/badges/crabfit.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/crabfit.maintain.svg)
+
+[![使用 YunoHost 安装 Crab Fit](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=crabfit)
+
+*[阅读此 README 的其它语言版本。](./ALL_README.md)*
+
+> *通过此软件包，您可以在 YunoHost 服务器上快速、简单地安装 Crab Fit。*  
+> *如果您还没有 YunoHost，请参阅[指南](https://yunohost.org/install)了解如何安装它。*
+
+## 概况
+
+Crab Fit helps you fit your event around everyone's schedules.
+Simply create an event above and send the link to everyone that is participating.
+Results update live and you will be able to see a heat-map of when everyone is free.
+
+## Features
+
+- Click and slide to select multiple time slots at once.
+- Editable using a one-time password
+
+
+**分发版本：** 1.0~ynh2
+
+**演示：** <https://crab.fit>
+
+## 截图
+
+![Crab Fit 的截图](./doc/screenshots/main.png)
+
+## 文档与资源
+
+- 官方应用网站： <https://crab.fit>
+- 官方用户文档： <https://github.com/GRA0007/crab.fit>
+- 官方管理文档： <https://github.com/GRA0007/crab.fit>
+- 上游应用代码库： <https://github.com/GRA0007/crab.fit>
+- YunoHost 商店： <https://apps.yunohost.org/app/crabfit>
+- 报告 bug： <https://github.com/YunoHost-Apps/crabfit_ynh/issues>
+
+## 开发者信息
+
+请向 [`testing` 分支](https://github.com/YunoHost-Apps/crabfit_ynh/tree/testing) 发送拉取请求。
+
+如要尝试 `testing` 分支，请这样操作：
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/crabfit_ynh/tree/testing --debug
+或
+sudo yunohost app upgrade crabfit -u https://github.com/YunoHost-Apps/crabfit_ynh/tree/testing --debug
+```
+
+**有关应用打包的更多信息：** <https://yunohost.org/packaging_apps>

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -35,8 +35,7 @@ function build_backend
 function build_frontend
 {
 	pushd $install_dir/frontend
-		ynh_exec_warn_less env "$ynh_node_load_PATH" $nodejs_path/corepack enable
-		ynh_exec_warn_less ynh_exec_as "$app" env "$ynh_node_load_PATH" $nodejs_path/yarn install --production --frozen-lockfile
+		ynh_exec_warn_less ynh_exec_as "$app" env "$ynh_node_load_PATH" $ynh_npm install next
 		ynh_exec_warn_less ynh_exec_as "$app" env "$ynh_node_load_PATH" $ynh_npm run build
 	popd
 


### PR DESCRIPTION
## Problem

- Missing dependencies on `eslint` that is only present in `devDependencies` resulting in compilation failures
- Why it broke without change in packaging or upstream is a mystery

## Solution

- The quick solution is to let `nextjs` do its magic and not let `yarn` get in the way

## PR Status

- [ ] Code finished and ready to be reviewed/tested
  - There might be a package version bump needed but otherwise good to go :+1:  
  - Not sure where the automatic README update come from though
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
